### PR TITLE
Fix hooks usage in transaction table

### DIFF
--- a/src/components/Transactions/TransactionsDataTable/Columns.tsx
+++ b/src/components/Transactions/TransactionsDataTable/Columns.tsx
@@ -7,6 +7,12 @@ import { formatCurrency } from '@/lib/currencies';
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
 
+function AmountCell({ amount }: { amount: number }) {
+  const { currency, rate } = useCurrency();
+  const formatted = formatCurrency(amount * rate, currency);
+  return <div className="text-left font-medium">{formatted}</div>;
+}
+
 export type TransactionTableEntry = {
   id: string;
   type: 'deposit' | 'withdrawal' | 'internal_transfer' | 'external_transfer';
@@ -95,12 +101,8 @@ export const columns: ColumnDef<TransactionTableEntry>[] = [
     enableSorting: true,
     sortingFn: 'basic',
     cell: ({ row }) => {
-      const { currency, rate } = useCurrency();
-
       const amount = parseFloat(row.getValue('amount'));
-      const formatted = formatCurrency(amount * rate, currency);
-
-      return <div className="text-left font-medium">{formatted}</div>;
+      return <AmountCell amount={amount} />;
     },
   },
   {

--- a/src/components/TransactionsDataTable/Columns.tsx
+++ b/src/components/TransactionsDataTable/Columns.tsx
@@ -7,6 +7,12 @@ import { formatCurrency } from '@/lib/currencies';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 
+function AmountCell({ amount }: { amount: number }) {
+  const { currency, rate } = useCurrency();
+  const formatted = formatCurrency(amount * rate, currency);
+  return <div className="text-left font-medium">{formatted}</div>;
+}
+
 export type TransactionTableEntry = {
   id: string;
   type: 'deposit' | 'withdrawal' | 'internal_transfer' | 'external_transfer';
@@ -95,12 +101,8 @@ export const columns: ColumnDef<TransactionTableEntry>[] = [
     enableSorting: true,
     sortingFn: 'basic',
     cell: ({ row }) => {
-      const { currency, rate } = useCurrency();
-
       const amount = parseFloat(row.getValue('amount'));
-      const formatted = formatCurrency(amount * rate, currency);
-
-      return <div className="text-left font-medium">{formatted}</div>;
+      return <AmountCell amount={amount} />;
     },
   },
   {


### PR DESCRIPTION
## Summary
- move hook usage into a dedicated `AmountCell` component used by transaction tables

## Testing
- `pnpm lint` *(fails: Unexpected any)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848183be794833087e783621151fc2f